### PR TITLE
Check structure of sparse matrix constructor.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ deps/usr/
 deps/deps\.jl
 
 deps/build\.log
+
+test/Project.toml
+test/Manifest.toml
+test/test_csv.csv

--- a/src/KaHyPar.jl
+++ b/src/KaHyPar.jl
@@ -77,7 +77,7 @@ end
 
 #Default weights are 1
 function HyperGraph(A::SparseMatrixCSC)
-    _check_structure(A) && @warn("Incidence matrix contains an empty column (i.e. a hyperedge not connected to any vertices).  This might lead to a segmentation fault when partitioning.")
+    _check_structure(A) && error("Incidence matrix contains an empty column (i.e. a hyperedge not connected to any vertices).  KaHyPar does not support empty hyperedges.")
     N_v,N_e = size(A)
     vertex_weights = kahypar_hypernode_id_t.(ones(N_v))
     edge_weights = kahypar_hyperedge_id_t.(ones(N_e))

--- a/src/KaHyPar.jl
+++ b/src/KaHyPar.jl
@@ -46,6 +46,7 @@ end
 HyperGraph(num_vertices,edge_indices,hyperedges) = HyperGraph(num_vertices,edge_indices,hyperedges,kahypar_hypernode_weight_t.(ones(num_vertices)),
 kahypar_hyperedge_weight_t.(ones(length(edge_indices) - 1)),nothing)
 
+
 """
 KaHyPar.HyperGraph(A::SparseMatrixCSC,vertex_weights::Vector{Int64},edge_weights::Vector{Int64})
 Create Hypergraph from a sparse matrix representing the incidence matrix (rows are nodes, columns are edges)
@@ -76,10 +77,15 @@ end
 
 #Default weights are 1
 function HyperGraph(A::SparseMatrixCSC)
+    _check_structure(A) && warning("Incidence matrix contains an empty column (i.e. a hyperedge not connected to any vertices).  This might lead to a segmentation fault when partitioning.")
     N_v,N_e = size(A)
     vertex_weights = kahypar_hypernode_id_t.(ones(N_v))
     edge_weights = kahypar_hyperedge_id_t.(ones(N_e))
     return HyperGraph(A,vertex_weights,edge_weights)
+end
+
+function _check_structure(A::SparseMatrixCSC)
+    return any(sum(A,dims = 1) .== 0) #check whether any columns (hyperedges) are empty
 end
 
 @deprecate hypergraph HyperGraph

--- a/src/KaHyPar.jl
+++ b/src/KaHyPar.jl
@@ -77,7 +77,7 @@ end
 
 #Default weights are 1
 function HyperGraph(A::SparseMatrixCSC)
-    _check_structure(A) && warning("Incidence matrix contains an empty column (i.e. a hyperedge not connected to any vertices).  This might lead to a segmentation fault when partitioning.")
+    _check_structure(A) && @warn("Incidence matrix contains an empty column (i.e. a hyperedge not connected to any vertices).  This might lead to a segmentation fault when partitioning.")
     N_v,N_e = size(A)
     vertex_weights = kahypar_hypernode_id_t.(ones(N_v))
     edge_weights = kahypar_hyperedge_id_t.(ones(N_e))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,14 +4,15 @@ using KaHyPar
 println("running tests...")
 
 println("testing partition")
-
 @test include("test_partition.jl")
+
+println("testing structure warning")
+@test include("test_check_structure.jl")
 
 println("testing load config file")
 @test include("test_load_configuration.jl")
 
 println("testing weights")
-
 @test include("test_weights.jl")
 
 println("testing improve partition")

--- a/test/test_check_structure.jl
+++ b/test/test_check_structure.jl
@@ -8,5 +8,6 @@ V = Int.(ones(length(I)))
 A = sparse(I,J,V)
 A[:,2] .= 0
 
-h = KaHyPar.HyperGraph(A)
-KaHyPar.partition(h,2,configuration = :edge_cut)
+@test_logs (:warn,"Incidence matrix contains an empty column (i.e. a hyperedge not connected to any vertices).  This might lead to a segmentation fault when partitioning.")  h = KaHyPar.HyperGraph(A)
+
+true

--- a/test/test_check_structure.jl
+++ b/test/test_check_structure.jl
@@ -1,0 +1,12 @@
+using KaHyPar
+using SparseArrays
+
+I = [1,3,1,2,4,5,4,5,7,3,6,7]
+J = [1,1,2,2,2,2,3,3,3,4,4,4]
+V = Int.(ones(length(I)))
+
+A = sparse(I,J,V)
+A[:,2] .= 0
+
+h = KaHyPar.HyperGraph(A)
+KaHyPar.partition(h,2,configuration = :edge_cut)

--- a/test/test_check_structure.jl
+++ b/test/test_check_structure.jl
@@ -8,6 +8,6 @@ V = Int.(ones(length(I)))
 A = sparse(I,J,V)
 A[:,2] .= 0
 
-@test_logs (:warn,"Incidence matrix contains an empty column (i.e. a hyperedge not connected to any vertices).  This might lead to a segmentation fault when partitioning.")  h = KaHyPar.HyperGraph(A)
+@test_throws ErrorException("Incidence matrix contains an empty column (i.e. a hyperedge not connected to any vertices).  KaHyPar does not support empty hyperedges.")  h = KaHyPar.HyperGraph(A)
 
 true


### PR DESCRIPTION
Added a `_check_structure` function to the sparse matrix constructor in reference to issue #5 .  This will check for columns with no entries (i.e. empty hyperedges) and throw a warning that it might result in a seg fault.  I don't want to throw an error since sometimes KaHyPar still works with unconnected hyperedges.

Also added a quick test that makes sure the warning is thrown.