### PR TITLE
remove 1.0 tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
           - '1'
           - 'nightly'
         os:


### PR DESCRIPTION
Removing tests for Julia 1.0 (for now).  We will need to make some adjustments to support Julia 1.0-1.2.  In the meantime, users can hit v0.1.0 if they're using the Linux version.  We can work on supporting older Julia versions for the next PR.