### PR TITLE
restrict KaHyPar_jll version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KaHyPar"
 uuid = "2a6221f6-aa48-11e9-3542-2d9e0ef01880"
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 KaHyPar_jll = "87a0c12d-51e1-52a8-b1ed-2b00825fe6a4"
@@ -9,8 +9,8 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-KaHyPar_jll = "1"
-julia = "1"
+KaHyPar_jll = "= 1.2.1"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
This is a quick PR to set the dependency on the KaHyPar_jll file. We were able to build and host new binaries for KaHyPar v1.3.0 (see https://github.com/JuliaBinaryWrappers/KaHyPar_jll.jl) including the macos M1 binary. However, I noticed some new errors when trying to run the KaHyPar.jl tests. I think we should force the current Julia interface to use KaHyPar v1.2.1 until I can figure out what's going on with the tests.