### PR TITLE
Update jll version; update readme; do code formatting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "KaHyPar"
 uuid = "2a6221f6-aa48-11e9-3542-2d9e0ef01880"
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 KaHyPar_jll = "87a0c12d-51e1-52a8-b1ed-2b00825fe6a4"
@@ -9,7 +9,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-KaHyPar_jll = "= 1.3.0"
+KaHyPar_jll = "= 1.3.3"
 julia = "1.6"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,39 @@ KaHyPar is a &nbsp;
 pkg> add KaHyPar
 ```
 
+## Usage
+KaHyPar.jl natively accepts an incidence matrix as a Julia sparse matrix. 
+The following snippet shows how to define and partition a simple hypergraph that contains 7 vertices and 4 hyperedges.
+
+```julia
+using KaHyPar
+using SparseArrays
+
+# setup incidence matrix
+# I and J represent non-zero coordinates in the incidence matrix
+I = [1, 3, 1, 2, 4, 5, 4, 5, 7, 3, 6, 7]
+J = [1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4]
+V = Int.(ones(length(I))) # can technically be any non-zero value
+
+# create the incidence matrix
+A = sparse(I, J, V)
+
+# create a KaHyPar hypergraph
+h = KaHyPar.HyperGraph(A)
+
+# partition with default edge_cut configuration with maximum imbalance of 10%
+KaHyPar.partition(h, 2; configuration=:edge_cut, imbalance=0.1)
+
+# partition with default connectivity configuration with maximum imbalance of 10%
+KaHyPar.partition(h, 2; configuration=:connectivity, imbalance=0.1)
+
+# partition with given configuration file
+KaHyPar.partition(h, 2; configuration=joinpath(@__DIR__, "km1_rKaHyPar_sea20.ini"))
+```
+
+It is also possible to partition with node and edge weights, set target block weights, set fixed vertices, or run improvement on existing partitions. The Julia API 
+is not documented, but the [test files](https://github.com/kahypar/KaHyPar.jl/tree/master/test) show how to use the aforementioned features.
+
 ## License
 
 This Julia wrapper package is released under MIT License.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ A = sparse(I, J, V)
 # create a KaHyPar hypergraph
 h = KaHyPar.HyperGraph(A)
 
-# partition with default edge_cut configuration with maximum imbalance of 10%
+# partition with default edge-cut configuration with maximum imbalance of 10%
 KaHyPar.partition(h, 2; configuration=:edge_cut, imbalance=0.1)
 
 # partition with default connectivity configuration with maximum imbalance of 10%
@@ -57,7 +57,7 @@ KaHyPar.partition(h, 2; configuration=:connectivity, imbalance=0.1)
 Configuration files may also be used to define the partition options like the following snippet. Some 
 sample configuration files can be found [here](https://github.com/kahypar/KaHyPar.jl/tree/master/src/config).
 ```julia
-# partition with given configuration file (assumes file is in your path)
+# partition with given configuration filepath
 KaHyPar.partition(h, 2; configuration="km1_rKaHyPar_sea20.ini")
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,13 @@ KaHyPar.partition(h, 2; configuration=:edge_cut, imbalance=0.1)
 
 # partition with default connectivity configuration with maximum imbalance of 10%
 KaHyPar.partition(h, 2; configuration=:connectivity, imbalance=0.1)
+```
 
-# partition with given configuration file
-KaHyPar.partition(h, 2; configuration=joinpath(@__DIR__, "km1_rKaHyPar_sea20.ini"))
+Configuration files may also be used to define the partition options like the following snippet. Some 
+sample configuration files can be found [here](https://github.com/kahypar/KaHyPar.jl/tree/master/src/config).
+```julia
+# partition with given configuration file (assumes file is in your path)
+KaHyPar.partition(h, 2; configuration="km1_rKaHyPar_sea20.ini")
 ```
 
 It is also possible to partition with node and edge weights, set target block weights, set fixed vertices, or run improvement on existing partitions. The Julia API 

--- a/src/KaHyPar.jl
+++ b/src/KaHyPar.jl
@@ -5,7 +5,7 @@ using LinearAlgebra
 using Libdl
 using KaHyPar_jll: libkahypar
 
-const default_configuration = joinpath(@__DIR__,"config/cut_kKaHyPar_sea20.ini")
+const default_configuration = joinpath(@__DIR__, "config/cut_kKaHyPar_sea20.ini")
 
 # KaHyPar C API
 include("kahypar_h.jl")
@@ -27,56 +27,80 @@ mutable struct HyperGraph
 end
 
 #Julia HyperGraph object constructor
-function HyperGraph(num_vertices,edge_indices,hyperedges,vertex_weights,edge_weights)
-    context =  kahypar_context_new()
+function HyperGraph(num_vertices, edge_indices, hyperedges, vertex_weights, edge_weights)
+    context = kahypar_context_new()
     num_edges = kahypar_hyperedge_id_t(length(edge_indices) - 1)
-    hypergraph = HyperGraph(context,nothing,num_vertices,edge_indices,hyperedges,vertex_weights,edge_weights,nothing)
+    hypergraph = HyperGraph(
+        context,
+        nothing,
+        num_vertices,
+        edge_indices,
+        hyperedges,
+        vertex_weights,
+        edge_weights,
+        nothing,
+    )
     return hypergraph
 end
 
-HyperGraph(num_vertices,edge_indices,hyperedges) = HyperGraph(num_vertices,edge_indices,hyperedges,kahypar_hypernode_weight_t.(ones(num_vertices)),
-kahypar_hyperedge_weight_t.(ones(length(edge_indices) - 1)),nothing)
-
+function HyperGraph(num_vertices, edge_indices, hyperedges)
+    return HyperGraph(
+        num_vertices,
+        edge_indices,
+        hyperedges,
+        kahypar_hypernode_weight_t.(ones(num_vertices)),
+        kahypar_hyperedge_weight_t.(ones(length(edge_indices) - 1)),
+        nothing,
+    )
+end
 
 """
 KaHyPar.HyperGraph(A::SparseMatrixCSC,vertex_weights::Vector{Int64},edge_weights::Vector{Int64})
 Create Hypergraph from a sparse matrix representing the incidence matrix (rows are nodes, columns are edges)
 """
-function HyperGraph(A::SparseMatrixCSC,vertex_weights::Vector,edge_weights::Vector)
-    N_v,N_e = size(A)
+function HyperGraph(A::SparseMatrixCSC, vertex_weights::Vector, edge_weights::Vector)
+    N_v, N_e = size(A)
     @assert length(vertex_weights) == N_v
     @assert length(edge_weights) == N_e
 
-    edge_indices = Vector{Csize_t}(undef, N_e+1)
+    edge_indices = Vector{Csize_t}(undef, N_e + 1)
     edge_indices[1] = 0   #must start at zero for C interface
     hyperedges = Vector{kahypar_hyperedge_id_t}(undef, nnz(A))
     hyperedge_i = 0
     @inbounds for j in 1:N_e
         n_rows = 0
-        for k in A.colptr[j] : (A.colptr[j+1] - 1)
+        for k in A.colptr[j]:(A.colptr[j + 1] - 1)
             i = A.rowval[k]
             n_rows += 1
             hyperedge_i += 1
             hyperedges[hyperedge_i] = i - 1  #subtract 1 for C interface
         end
-        edge_indices[j+1] = edge_indices[j] + n_rows
+        edge_indices[j + 1] = edge_indices[j] + n_rows
     end
     resize!(hyperedges, hyperedge_i)
 
-    return HyperGraph(kahypar_hypernode_id_t(N_v),edge_indices,hyperedges,kahypar_hypernode_weight_t.(vertex_weights),kahypar_hyperedge_weight_t.(edge_weights))
+    return HyperGraph(
+        kahypar_hypernode_id_t(N_v),
+        edge_indices,
+        hyperedges,
+        kahypar_hypernode_weight_t.(vertex_weights),
+        kahypar_hyperedge_weight_t.(edge_weights),
+    )
 end
 
 #Default weights are 1
 function HyperGraph(A::SparseMatrixCSC)
-    _check_structure(A) && error("Incidence matrix contains an empty column (i.e. a hyperedge not connected to any vertices).  KaHyPar does not support empty hyperedges.")
-    N_v,N_e = size(A)
+    _check_structure(A) && error(
+        "Incidence matrix contains an empty column (i.e. a hyperedge not connected to any vertices).  KaHyPar does not support empty hyperedges.",
+    )
+    N_v, N_e = size(A)
     vertex_weights = kahypar_hypernode_id_t.(ones(N_v))
     edge_weights = kahypar_hyperedge_id_t.(ones(N_e))
-    return HyperGraph(A,vertex_weights,edge_weights)
+    return HyperGraph(A, vertex_weights, edge_weights)
 end
 
 function _check_structure(A::SparseMatrixCSC)
-    return any(sum(A,dims = 1) .== 0) #check whether any columns (hyperedges) are empty
+    return any(sum(A; dims=1) .== 0) #check whether any columns (hyperedges) are empty
 end
 
 @deprecate hypergraph HyperGraph
@@ -85,74 +109,137 @@ end
     KaHyPar.partition(H, kparts; options_file = "")
     Partition the hypergraph `H` in `k` parts.  Returns a partition vector
 """
-partition(H, kparts;imbalance = 0.03, configuration = default_configuration) = partition(HyperGraph(H), kparts,imbalance = imbalance, configuration = configuration)
+function partition(H, kparts; imbalance=0.03, configuration=default_configuration)
+    return partition(
+        HyperGraph(H), kparts; imbalance=imbalance, configuration=configuration
+    )
+end
 
 #Simple partition wrapper.  We create a new context, load the file, partition the hypergraph, and free the context.
-function partition(H::HyperGraph, kparts::Integer; imbalance::Number = 0.03, configuration::Union{Nothing,Symbol,String} = nothing)
+function partition(
+    H::HyperGraph,
+    kparts::Integer;
+    imbalance::Number=0.03,
+    configuration::Union{Nothing,Symbol,String}=nothing,
+)
     objective = Cint(0)
     parts = Vector{kahypar_partition_id_t}(undef, H.n_vertices)
     num_hyperedges = kahypar_hyperedge_id_t(length(H.edge_indices) - 1)
-    if isa(configuration,Symbol)
+    if isa(configuration, Symbol)
         if configuration == :edge_cut
-            config_file =  joinpath(@__DIR__ ,"config/cut_kKaHyPar_sea20.ini")
+            config_file = joinpath(@__DIR__, "config/cut_kKaHyPar_sea20.ini")
         elseif configuration == :connectivity
-            config_file =  joinpath(@__DIR__ ,"config/km1_kKaHyPar_sea20.ini")
+            config_file = joinpath(@__DIR__, "config/km1_kKaHyPar_sea20.ini")
         else
             error("Unsupported configuration option given")
         end
         H.config = config_file
-    elseif isa(configuration,String)
+    elseif isa(configuration, String)
         H.config = configuration
     elseif configuration == nothing && H.config == nothing
         H.config = default_configuration
     end
-    kahypar_configure_context_from_file(H.context,H.config)
+    kahypar_configure_context_from_file(H.context, H.config)
     if H.k_hypergraph == nothing
-        kahypar_partition(H.n_vertices, num_hyperedges, Cdouble(imbalance), kahypar_partition_id_t(kparts),H.v_weights, H.e_weights, H.edge_indices,H.hyperedges, objective, H.context, parts)
+        kahypar_partition(
+            H.n_vertices,
+            num_hyperedges,
+            Cdouble(imbalance),
+            kahypar_partition_id_t(kparts),
+            H.v_weights,
+            H.e_weights,
+            H.edge_indices,
+            H.hyperedges,
+            objective,
+            H.context,
+            parts,
+        )
     else
-        kahypar_partition_hypergraph(H.k_hypergraph,kahypar_partition_id_t(kparts),Cdouble(imbalance),objective,H.context,parts)
+        kahypar_partition_hypergraph(
+            H.k_hypergraph,
+            kahypar_partition_id_t(kparts),
+            Cdouble(imbalance),
+            objective,
+            H.context,
+            parts,
+        )
     end
     #kahypar_context_free(context)
     return Int.(parts)  #typecast result back to julia Integer
 end
 
 #Load a partitioning configuration from a file
-function set_config_file(H::HyperGraph,config_file::String)
+function set_config_file(H::HyperGraph, config_file::String)
     H.config = config_file
     return nothing
 end
 
 #Improve an existing partition
-function improve_partition(H::HyperGraph, kparts::Integer, input_partition::Vector;num_iterations::Int64 = 10, imbalance::Number = 0.03)
+function improve_partition(
+    H::HyperGraph,
+    kparts::Integer,
+    input_partition::Vector;
+    num_iterations::Int64=10,
+    imbalance::Number=0.03,
+)
     objective = Cint(0)
     parts = Vector{kahypar_partition_id_t}(undef, H.n_vertices)
     num_hyperedges = kahypar_hyperedge_id_t(length(H.edge_indices) - 1)
     input_partition = kahypar_partition_id_t.(input_partition)
     if H.k_hypergraph == nothing
-        kahypar_improve_partition(H.n_vertices,num_hyperedges,Cdouble(imbalance),kahypar_partition_id_t(kparts),
-        H.v_weights, H.e_weights, H.edge_indices,H.hyperedges,input_partition,num_iterations,objective, H.context, parts)
+        kahypar_improve_partition(
+            H.n_vertices,
+            num_hyperedges,
+            Cdouble(imbalance),
+            kahypar_partition_id_t(kparts),
+            H.v_weights,
+            H.e_weights,
+            H.edge_indices,
+            H.hyperedges,
+            input_partition,
+            num_iterations,
+            objective,
+            H.context,
+            parts,
+        )
     else #we already have a hypergraph object
-        kahypar_improve_hypergraph_partition(H.k_hypergraph,kahypar_partition_id_t(kparts),Cdouble(imbalance),objective,
-        H.context,input_partition,num_iterations,parts)
+        kahypar_improve_hypergraph_partition(
+            H.k_hypergraph,
+            kahypar_partition_id_t(kparts),
+            Cdouble(imbalance),
+            objective,
+            H.context,
+            input_partition,
+            num_iterations,
+            parts,
+        )
     end
     return Int.(parts)  #typecast result back to julia Integer
 end
 
-function set_target_block_weights(H::HyperGraph,block_weights::Vector{Int64})
-    @assert length(block_weights) <= H.n_vertices  "Number of block weights ($(length(block_weights))) must be less than or equal to number of vertices ($(H.n_vertices)) "
+function set_target_block_weights(H::HyperGraph, block_weights::Vector{Int64})
+    @assert length(block_weights) <= H.n_vertices "Number of block weights ($(length(block_weights))) must be less than or equal to number of vertices ($(H.n_vertices)) "
     @assert sum(block_weights) >= sum(H.v_weights) "Sum of individual part weights must be greater than sum of vertex weights"
     n_blocks = kahypar_hypernode_id_t(length(block_weights))
     block_weights = kahypar_hypernode_weight_t.(block_weights)
-    kahypar_set_custom_target_block_weights(n_blocks,block_weights,H.context)
+    kahypar_set_custom_target_block_weights(n_blocks, block_weights, H.context)
     return nothing
 end
 
 #Fix vertices
-function fix_vertices(H::HyperGraph,num_blocks::Int64,fixed_vertex_blocks::Vector{Int64})
+function fix_vertices(H::HyperGraph, num_blocks::Int64, fixed_vertex_blocks::Vector{Int64})
     num_edges = kahypar_hyperedge_id_t(length(H.edge_indices) - 1)
-    k_hypergraph = kahypar_create_hypergraph(kahypar_partition_id_t(num_blocks),H.n_vertices,num_edges,H.edge_indices,H.hyperedges,H.e_weights,H.v_weights)
+    k_hypergraph = kahypar_create_hypergraph(
+        kahypar_partition_id_t(num_blocks),
+        H.n_vertices,
+        num_edges,
+        H.edge_indices,
+        H.hyperedges,
+        H.e_weights,
+        H.v_weights,
+    )
     H.k_hypergraph = k_hypergraph
-    kahypar_set_fixed_vertices(H.k_hypergraph,kahypar_partition_id_t.(fixed_vertex_blocks))
+    kahypar_set_fixed_vertices(H.k_hypergraph, kahypar_partition_id_t.(fixed_vertex_blocks))
     return nothing
 end
 

--- a/src/kahypar_h.jl
+++ b/src/kahypar_h.jl
@@ -5,64 +5,64 @@ const kahypar_hyperedge_weight_t = Cint
 const kahypar_partition_id_t = Cint
 
 #Struct corresponding to underlying KaHyPar context object
-mutable struct kahypar_context_t
-end
+mutable struct kahypar_context_t end
 
 #Create a kaypar context.  Return a pointer to it.
 function kahypar_context_new()
-    context = ccall((:kahypar_context_new,libkahypar),Ptr{kahypar_context_t},())
+    context = ccall((:kahypar_context_new, libkahypar), Ptr{kahypar_context_t}, ())
     return context
 end
 
 #Configure a KaHyPar context from a configuration file
-function kahypar_configure_context_from_file(context::Ref{kahypar_context_t},filename::String)
-    ccall((:kahypar_configure_context_from_file,libkahypar),
+function kahypar_configure_context_from_file(
+    context::Ref{kahypar_context_t}, filename::String
+)
+    return ccall(
+        (:kahypar_configure_context_from_file, libkahypar),
         Cvoid,
-        (Ref{kahypar_context_t},Cstring),
+        (Ref{kahypar_context_t}, Cstring),
         context,
-        filename)
+        filename,
+    )
 end
 
 #Free the context
 function kahypar_context_free(context::Ref{kahypar_context_t})
-    ccall((:kahypar_context_free,libkahypar),
-    Cvoid,
-    (Ref{kahypar_context_t},),
-    context)
+    return ccall(
+        (:kahypar_context_free, libkahypar), Cvoid, (Ref{kahypar_context_t},), context
+    )
 end
 
 #Set seed
 function kahypar_set_seed(context::Ref{kahypar_context_t}, seed)
-    ccall((:kahypar_set_seed,libkahypar), Cvoid, (Ref{kahypar_context_t}, Cint), context, seed)
+    return ccall(
+        (:kahypar_set_seed, libkahypar),
+        Cvoid,
+        (Ref{kahypar_context_t}, Cint),
+        context,
+        seed,
+    )
 end
 
 #Set custom block weights
-function kahypar_set_custom_target_block_weights(num_blocks::kahypar_hypernode_id_t,block_weights::Vector{kahypar_hypernode_weight_t},kahypar_context::Ref{kahypar_context_t})
-    ccall((:kahypar_set_custom_target_block_weights,libkahypar),
-    Cvoid,
-    (kahypar_partition_id_t,Ptr{kahypar_hypernode_weight_t},Ptr{kahypar_context_t}),
-    num_blocks,block_weights,kahypar_context
+function kahypar_set_custom_target_block_weights(
+    num_blocks::kahypar_hypernode_id_t,
+    block_weights::Vector{kahypar_hypernode_weight_t},
+    kahypar_context::Ref{kahypar_context_t},
+)
+    ccall(
+        (:kahypar_set_custom_target_block_weights, libkahypar),
+        Cvoid,
+        (kahypar_partition_id_t, Ptr{kahypar_hypernode_weight_t}, Ptr{kahypar_context_t}),
+        num_blocks,
+        block_weights,
+        kahypar_context,
     )
-    return
+    return nothing
 end
 
 #Perform kahypar partitioning given hypergraph information.
-function kahypar_partition(num_vertices, num_hyperedges, imbalance, num_blocks,
-                          vertex_weights, hyperedge_weights, hyperedge_indices,
-                          hyperedges, objective, context, partition)
-    ccall((:kahypar_partition,libkahypar),
-    Cvoid,
-    (kahypar_hypernode_id_t,              #num vertices
-    kahypar_hyperedge_id_t,               #num hyperedges
-    Cdouble,                              #imbalance
-    kahypar_partition_id_t,               #num blocks
-    Ptr{kahypar_hypernode_weight_t},      #hypernode weights
-    Ptr{kahypar_hyperedge_weight_t},      #hyperedge weights
-    Ptr{Csize_t},                         #hyperedge indices
-    Ptr{kahypar_hyperedge_id_t},          #hyperedges
-    Ref{kahypar_hyperedge_weight_t},      #Reference to objective value
-    Ptr{kahypar_context_t},               #context (should this be a Ptr or a Ref?)
-    Ref{kahypar_partition_id_t}),         #partition
+function kahypar_partition(
     num_vertices,
     num_hyperedges,
     imbalance,
@@ -73,30 +73,41 @@ function kahypar_partition(num_vertices, num_hyperedges, imbalance, num_blocks,
     hyperedges,
     objective,
     context,
-    partition
+    partition,
+)
+    ccall(
+        (:kahypar_partition, libkahypar),
+        Cvoid,
+        (
+            kahypar_hypernode_id_t,              #num vertices
+            kahypar_hyperedge_id_t,               #num hyperedges
+            Cdouble,                              #imbalance
+            kahypar_partition_id_t,               #num blocks
+            Ptr{kahypar_hypernode_weight_t},      #hypernode weights
+            Ptr{kahypar_hyperedge_weight_t},      #hyperedge weights
+            Ptr{Csize_t},                         #hyperedge indices
+            Ptr{kahypar_hyperedge_id_t},          #hyperedges
+            Ref{kahypar_hyperedge_weight_t},      #Reference to objective value
+            Ptr{kahypar_context_t},               #context (should this be a Ptr or a Ref?)
+            Ref{kahypar_partition_id_t},
+        ),         #partition
+        num_vertices,
+        num_hyperedges,
+        imbalance,
+        num_blocks,
+        vertex_weights,
+        hyperedge_weights,
+        hyperedge_indices,
+        hyperedges,
+        objective,
+        context,
+        partition,
     )
-    return
+    return nothing
 end
 
 #Improve an existing hypergraph partition
-function kahypar_improve_partition(num_vertices, num_hyperedges, imbalance, num_blocks,
-                          vertex_weights, hyperedge_weights, hyperedge_indices,
-                          hyperedges,input_partition,num_improvement_iterations,objective,context,partition)
-    ccall((:kahypar_improve_partition,libkahypar),
-    Cvoid,
-    (kahypar_hypernode_id_t,              #num vertices
-    kahypar_hyperedge_id_t,               #num hyperedges
-    Cdouble,                              #imbalance
-    kahypar_partition_id_t,               #num blocks
-    Ptr{kahypar_hypernode_weight_t},      #hypernode weights
-    Ptr{kahypar_hyperedge_weight_t},      #hyperedge weights
-    Ptr{Csize_t},                         #hyperedge indices
-    Ptr{kahypar_hyperedge_id_t},          #hyperedges
-    Ptr{kahypar_partition_id_t},          #input partition
-    Csize_t,                              #number of improvement iterations
-    Ref{kahypar_hyperedge_weight_t},      #Reference to objective value
-    Ptr{kahypar_context_t},               #context (should this be a Ptr or a Ref?)
-    Ref{kahypar_partition_id_t}),         #return partition
+function kahypar_improve_partition(
     num_vertices,
     num_hyperedges,
     imbalance,
@@ -109,21 +120,63 @@ function kahypar_improve_partition(num_vertices, num_hyperedges, imbalance, num_
     num_improvement_iterations,
     objective,
     context,
-    partition
+    partition,
+)
+    ccall(
+        (:kahypar_improve_partition, libkahypar),
+        Cvoid,
+        (
+            kahypar_hypernode_id_t,              #num vertices
+            kahypar_hyperedge_id_t,               #num hyperedges
+            Cdouble,                              #imbalance
+            kahypar_partition_id_t,               #num blocks
+            Ptr{kahypar_hypernode_weight_t},      #hypernode weights
+            Ptr{kahypar_hyperedge_weight_t},      #hyperedge weights
+            Ptr{Csize_t},                         #hyperedge indices
+            Ptr{kahypar_hyperedge_id_t},          #hyperedges
+            Ptr{kahypar_partition_id_t},          #input partition
+            Csize_t,                              #number of improvement iterations
+            Ref{kahypar_hyperedge_weight_t},      #Reference to objective value
+            Ptr{kahypar_context_t},               #context (should this be a Ptr or a Ref?)
+            Ref{kahypar_partition_id_t},
+        ),         #return partition
+        num_vertices,
+        num_hyperedges,
+        imbalance,
+        num_blocks,
+        vertex_weights,
+        hyperedge_weights,
+        hyperedge_indices,
+        hyperedges,
+        input_partition,
+        num_improvement_iterations,
+        objective,
+        context,
+        partition,
     )
-    return
+    return nothing
 end
 
-function kahypar_validate_input(num_vertices, num_hyperedges, hyperedge_indices, hyperedges, hyperedge_weights, vertex_weights, print_errors)
-    ccall((:kahypar_validate_input,libkahypar),
+function kahypar_validate_input(
+    num_vertices,
+    num_hyperedges,
+    hyperedge_indices,
+    hyperedges,
+    hyperedge_weights,
+    vertex_weights,
+    print_errors,
+)
+    return ccall(
+        (:kahypar_validate_input, libkahypar),
         Cvoid,
-        (kahypar_hypernode_id_t,
-        kahypar_hyperedge_id_t,
-        Ref{Csize_t},
-        Ref{kahypar_hyperedge_id_t},
-        Ref{kahypar_hyperedge_weight_t},
-        Ref{kahypar_hypernode_weight_t},
-        Cint, # there is no Cbool type in Julia
+        (
+            kahypar_hypernode_id_t,
+            kahypar_hyperedge_id_t,
+            Ref{Csize_t},
+            Ref{kahypar_hyperedge_id_t},
+            Ref{kahypar_hyperedge_weight_t},
+            Ref{kahypar_hypernode_weight_t},
+            Cint, # there is no Cbool type in Julia
         ),
         num_vertices,
         num_hyperedges,
@@ -138,51 +191,75 @@ end
 ############################################################
 #New interface functions that use a KaHyPar hypergraph type
 #reference to the underlying C hypergraph type
-mutable struct kahypar_hypergraph_t
-end
+mutable struct kahypar_hypergraph_t end
 
 #create a KaHyPar hypergraph object
-function kahypar_create_hypergraph(num_blocks,num_vertices,num_hyperedges,hyperedge_indices,hyperedges,hyperedge_weights,vertex_weights)
-      k_hypergraph = ccall((:kahypar_create_hypergraph,libkahypar),
-          Ptr{kahypar_hypergraph_t},
-          (kahypar_partition_id_t,              #num blocks
-          kahypar_hypernode_id_t,               #num vertices
-          kahypar_hyperedge_id_t,               #num hyperedges
-          Ptr{Csize_t},                         #hyperedge indices
-          Ptr{kahypar_hyperedge_id_t},          #hyperedges
-          Ptr{kahypar_hyperedge_weight_t},      #hyperedge weights
-          Ptr{kahypar_hypernode_weight_t},      #vertex weights
-          ),
-          num_blocks,
-          num_vertices,
-          num_hyperedges,
-          hyperedge_indices,
-          hyperedges,
-          hyperedge_weights,
-          vertex_weights)
-      return k_hypergraph
+function kahypar_create_hypergraph(
+    num_blocks,
+    num_vertices,
+    num_hyperedges,
+    hyperedge_indices,
+    hyperedges,
+    hyperedge_weights,
+    vertex_weights,
+)
+    k_hypergraph = ccall(
+        (:kahypar_create_hypergraph, libkahypar),
+        Ptr{kahypar_hypergraph_t},
+        (
+            kahypar_partition_id_t,              #num blocks
+            kahypar_hypernode_id_t,               #num vertices
+            kahypar_hyperedge_id_t,               #num hyperedges
+            Ptr{Csize_t},                         #hyperedge indices
+            Ptr{kahypar_hyperedge_id_t},          #hyperedges
+            Ptr{kahypar_hyperedge_weight_t},      #hyperedge weights
+            Ptr{kahypar_hypernode_weight_t},      #vertex weights
+        ),
+        num_blocks,
+        num_vertices,
+        num_hyperedges,
+        hyperedge_indices,
+        hyperedges,
+        hyperedge_weights,
+        vertex_weights,
+    )
+    return k_hypergraph
 end
 
 #Create a hypergraph from an input file
-function kahypar_create_hypergraph_from_file(filename::String,num_blocks::kahypar_hypernode_id_t)
-  k_hypergraph = ccall((:kahypar_create_hypergraph_from_file,libkahypar),
-      Ptr{kahypar_hypergraph_t},
-      (Cstring,kahypar_partition_id_t),
-      filename,
-      num_blocks)
-      return k_hypergraph
+function kahypar_create_hypergraph_from_file(
+    filename::String, num_blocks::kahypar_hypernode_id_t
+)
+    k_hypergraph = ccall(
+        (:kahypar_create_hypergraph_from_file, libkahypar),
+        Ptr{kahypar_hypergraph_t},
+        (Cstring, kahypar_partition_id_t),
+        filename,
+        num_blocks,
+    )
+    return k_hypergraph
 end
 
-function kahypar_read_hypergraph_from_file(filename, num_vertices, num_hyperedges, hyperedge_indices, hyperedges, hyperedge_weights, vertex_weights)
-    ccall((:kahypar_read_hypergraph_from_file,libkahypar),
+function kahypar_read_hypergraph_from_file(
+    filename,
+    num_vertices,
+    num_hyperedges,
+    hyperedge_indices,
+    hyperedges,
+    hyperedge_weights,
+    vertex_weights,
+)
+    return ccall(
+        (:kahypar_read_hypergraph_from_file, libkahypar),
         Cvoid,
-        (Cstring,
-        Ref{kahypar_hypernode_id_t},
-        Ref{kahypar_hyperedge_id_t},
-        Ptr{Ptr{Csize_t}},
-        Ptr{Ptr{kahypar_hyperedge_id_t}},
-        Ptr{Ptr{kahypar_hyperedge_weight_t}},
-        Ptr{Ptr{kahypar_hypernode_weight_t}},
+        (
+            Cstring,
+            Ref{kahypar_hypernode_id_t},
+            Ref{kahypar_hyperedge_id_t},
+            Ptr{Ptr{Csize_t}},
+            Ptr{Ptr{kahypar_hyperedge_id_t}},
+            Ptr{Ptr{kahypar_hyperedge_weight_t}},
+            Ptr{Ptr{kahypar_hypernode_weight_t}},
         ),
         filename,
         num_vertices,
@@ -195,48 +272,47 @@ function kahypar_read_hypergraph_from_file(filename, num_vertices, num_hyperedge
 end
 
 #Partition a hypergraph object
-function kahypar_partition_hypergraph(k_hypergraph,num_blocks,imbalance,objective,context,partition)
-    ccall((:kahypar_partition_hypergraph,libkahypar),
-    Cvoid,
-    (Ptr{kahypar_hypergraph_t},           #hypergraph
-    kahypar_partition_id_t,               #num blocks
-    Cdouble,                              #imbalance
-    Ref{kahypar_hyperedge_weight_t},      #Reference to objective value
-    Ptr{kahypar_context_t},               #context (Should this be a Ptr or a Ref?)
-    Ref{kahypar_partition_id_t}),         #Partition
-    k_hypergraph,
-    num_blocks,
-    imbalance,
-    objective,
-    context,
-    partition
+function kahypar_partition_hypergraph(
+    k_hypergraph, num_blocks, imbalance, objective, context, partition
+)
+    ccall(
+        (:kahypar_partition_hypergraph, libkahypar),
+        Cvoid,
+        (
+            Ptr{kahypar_hypergraph_t},           #hypergraph
+            kahypar_partition_id_t,               #num blocks
+            Cdouble,                              #imbalance
+            Ref{kahypar_hyperedge_weight_t},      #Reference to objective value
+            Ptr{kahypar_context_t},               #context (Should this be a Ptr or a Ref?)
+            Ref{kahypar_partition_id_t},
+        ),         #Partition
+        k_hypergraph,
+        num_blocks,
+        imbalance,
+        objective,
+        context,
+        partition,
     )
-    return
+    return nothing
 end
 
 #Set fixed vertices in a hypergraph
-function kahypar_set_fixed_vertices(k_hypergraph::Ref{kahypar_hypergraph_t},fixed_vertex_blocks::Vector{kahypar_partition_id_t})
-    ccall((:kahypar_set_fixed_vertices,libkahypar),
+function kahypar_set_fixed_vertices(
+    k_hypergraph::Ref{kahypar_hypergraph_t},
+    fixed_vertex_blocks::Vector{kahypar_partition_id_t},
+)
+    ccall(
+        (:kahypar_set_fixed_vertices, libkahypar),
         Cvoid,
-        (Ptr{kahypar_hypergraph_t},
-        Ptr{kahypar_partition_id_t}),
+        (Ptr{kahypar_hypergraph_t}, Ptr{kahypar_partition_id_t}),
         k_hypergraph,
-        fixed_vertex_blocks)
-    return
+        fixed_vertex_blocks,
+    )
+    return nothing
 end
 
 #Improve a hypergraph object partition (which may contain fixed vertices)
-function kahypar_improve_hypergraph_partition(k_hypergraph,num_blocks,imbalance,objective,context,input_partition,num_improvement_iterations,improved_partition)
-    ccall((:kahypar_improve_hypergraph_partition,libkahypar),
-    Cvoid,
-    (Ptr{kahypar_hypergraph_t},           #hypergraph
-    kahypar_partition_id_t,               #num blocks
-    Cdouble,                              #imbalance
-    Ref{kahypar_hyperedge_weight_t},      #Reference to objective value
-    Ptr{kahypar_context_t},               #context (Should this be a Ptr or a Ref?)
-    Ptr{kahypar_partition_id_t},          #input partition
-    Csize_t,                              #number of improvement iterations
-    Ref{kahypar_partition_id_t}),         #return partition
+function kahypar_improve_hypergraph_partition(
     k_hypergraph,
     num_blocks,
     imbalance,
@@ -244,15 +320,39 @@ function kahypar_improve_hypergraph_partition(k_hypergraph,num_blocks,imbalance,
     context,
     input_partition,
     num_improvement_iterations,
-    improved_partition
+    improved_partition,
+)
+    ccall(
+        (:kahypar_improve_hypergraph_partition, libkahypar),
+        Cvoid,
+        (
+            Ptr{kahypar_hypergraph_t},           #hypergraph
+            kahypar_partition_id_t,               #num blocks
+            Cdouble,                              #imbalance
+            Ref{kahypar_hyperedge_weight_t},      #Reference to objective value
+            Ptr{kahypar_context_t},               #context (Should this be a Ptr or a Ref?)
+            Ptr{kahypar_partition_id_t},          #input partition
+            Csize_t,                              #number of improvement iterations
+            Ref{kahypar_partition_id_t},
+        ),         #return partition
+        k_hypergraph,
+        num_blocks,
+        imbalance,
+        objective,
+        context,
+        input_partition,
+        num_improvement_iterations,
+        improved_partition,
     )
-    return
+    return nothing
 end
 
 #Free a hypergraph object
 function kahypar_hypergraph_free(k_hypergraph::Ref{kahypar_hypergraph_t})
-    ccall((:kahypar_hypergraph_free,libkahypar),
-    Cvoid,
-    (Ref{kahypar_hypergraph_t},),
-    k_hypergraph)
+    return ccall(
+        (:kahypar_hypergraph_free, libkahypar),
+        Cvoid,
+        (Ref{kahypar_hypergraph_t},),
+        k_hypergraph,
+    )
 end

--- a/test/test_check_structure.jl
+++ b/test/test_check_structure.jl
@@ -1,13 +1,15 @@
 using KaHyPar
 using SparseArrays
 
-I = [1,3,1,2,4,5,4,5,7,3,6,7]
-J = [1,1,2,2,2,2,3,3,3,4,4,4]
+I = [1, 3, 1, 2, 4, 5, 4, 5, 7, 3, 6, 7]
+J = [1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4]
 V = Int.(ones(length(I)))
 
-A = sparse(I,J,V)
-A[:,2] .= 0
+A = sparse(I, J, V)
+A[:, 2] .= 0
 
-@test_throws ErrorException("Incidence matrix contains an empty column (i.e. a hyperedge not connected to any vertices).  KaHyPar does not support empty hyperedges.")  h = KaHyPar.HyperGraph(A)
+@test_throws ErrorException(
+    "Incidence matrix contains an empty column (i.e. a hyperedge not connected to any vertices).  KaHyPar does not support empty hyperedges.",
+) h = KaHyPar.HyperGraph(A)
 
 true

--- a/test/test_fix_vertices.jl
+++ b/test/test_fix_vertices.jl
@@ -1,21 +1,23 @@
 using KaHyPar
 using SparseArrays
 
-I = [1,3,1,2,4,5,4,5,7,3,6,7]
-J = [1,1,2,2,2,2,3,3,3,4,4,4]
+I = [1, 3, 1, 2, 4, 5, 4, 5, 7, 3, 6, 7]
+J = [1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4]
 V = Int.(ones(length(I)))
 
-A = sparse(I,J,V)
+A = sparse(I, J, V)
 
 h = KaHyPar.HyperGraph(A)
 
 #Free the first 3 vertices in the hypergraph (denoted using -1).  Fix vertices to blocks 1 and 2
-KaHyPar.fix_vertices(h,3,[-1,-1,-1,1,1,2,2])
+KaHyPar.fix_vertices(h, 3, [-1, -1, -1, 1, 1, 2, 2])
 
 #Partition with fixed vertices
-partition = KaHyPar.partition(h,3,configuration = :edge_cut,imbalance = 0.1)
+partition = KaHyPar.partition(h, 3; configuration=:edge_cut, imbalance=0.1)
 
 #Improve partition with fixed vertices
-improved_partition = KaHyPar.improve_partition(h,3,partition,num_iterations = 10,imbalance = 0.1)
+improved_partition = KaHyPar.improve_partition(
+    h, 3, partition; num_iterations=10, imbalance=0.1
+)
 
 true

--- a/test/test_improve_partition.jl
+++ b/test/test_improve_partition.jl
@@ -1,16 +1,16 @@
 using KaHyPar
 using SparseArrays
 
-I = [1,3,1,2,4,5,4,5,7,3,6,7]
-J = [1,1,2,2,2,2,3,3,3,4,4,4]
+I = [1, 3, 1, 2, 4, 5, 4, 5, 7, 3, 6, 7]
+J = [1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4]
 V = Int.(ones(length(I)))
 
-A = sparse(I,J,V)
+A = sparse(I, J, V)
 
 h = KaHyPar.HyperGraph(A)
 
-partition = KaHyPar.partition(h,2,configuration = :edge_cut)
+partition = KaHyPar.partition(h, 2; configuration=:edge_cut)
 
-improved_partition = KaHyPar.improve_partition(h,2,partition,num_iterations = 1)
+improved_partition = KaHyPar.improve_partition(h, 2, partition; num_iterations=1)
 
 true

--- a/test/test_load_configuration.jl
+++ b/test/test_load_configuration.jl
@@ -1,16 +1,16 @@
 using KaHyPar
 using SparseArrays
 
-I = [1,3,1,2,4,5,4,5,7,3,6,7]
-J = [1,1,2,2,2,2,3,3,3,4,4,4]
+I = [1, 3, 1, 2, 4, 5, 4, 5, 7, 3, 6, 7]
+J = [1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4]
 V = Int.(ones(length(I)))
 
-A = sparse(I,J,V)
+A = sparse(I, J, V)
 
 h = KaHyPar.HyperGraph(A)
 
-KaHyPar.set_config_file(h,"../src/config/km1_rKaHyPar_sea20.ini")
+KaHyPar.set_config_file(h, "../src/config/km1_rKaHyPar_sea20.ini")
 
-KaHyPar.partition(h,2)
+KaHyPar.partition(h, 2)
 
 true

--- a/test/test_partition.jl
+++ b/test/test_partition.jl
@@ -1,19 +1,20 @@
 using KaHyPar
 using SparseArrays
 
-I = [1,3,1,2,4,5,4,5,7,3,6,7]
-J = [1,1,2,2,2,2,3,3,3,4,4,4]
+I = [1, 3, 1, 2, 4, 5, 4, 5, 7, 3, 6, 7]
+J = [1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4]
 V = Int.(ones(length(I)))
 
-A = sparse(I,J,V)
+A = sparse(I, J, V)
 
 h = KaHyPar.HyperGraph(A)
 
-KaHyPar.partition(h,2,configuration = :edge_cut)
+KaHyPar.partition(h, 2; configuration=:edge_cut)
 
-KaHyPar.partition(h,2,configuration = :connectivity)
+KaHyPar.partition(h, 2; configuration=:connectivity)
 
-KaHyPar.partition(h,2,configuration = joinpath(@__DIR__,"../src/config/km1_rKaHyPar_sea20.ini"))
-
+KaHyPar.partition(
+    h, 2; configuration=joinpath(@__DIR__, "../src/config/km1_rKaHyPar_sea20.ini")
+)
 
 true

--- a/test/test_set_target_weights.jl
+++ b/test/test_set_target_weights.jl
@@ -1,16 +1,16 @@
 using KaHyPar
 using SparseArrays
 
-I = [1,3,1,2,4,5,4,5,7,3,6,7]
-J = [1,1,2,2,2,2,3,3,3,4,4,4]
+I = [1, 3, 1, 2, 4, 5, 4, 5, 7, 3, 6, 7]
+J = [1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4]
 V = Int.(ones(length(I)))
 
-A = sparse(I,J,V)
+A = sparse(I, J, V)
 
 h = KaHyPar.HyperGraph(A)
 
-KaHyPar.set_target_block_weights(h,[5,3])
+KaHyPar.set_target_block_weights(h, [5, 3])
 
-KaHyPar.partition(h,2,configuration = :edge_cut)
+KaHyPar.partition(h, 2; configuration=:edge_cut)
 
 true

--- a/test/test_weights.jl
+++ b/test/test_weights.jl
@@ -1,21 +1,23 @@
 using KaHyPar
 using SparseArrays
 
-I = [1,3,1,2,4,5,4,5,7,3,6,7]
-J = [1,1,2,2,2,2,3,3,3,4,4,4]
+I = [1, 3, 1, 2, 4, 5, 4, 5, 7, 3, 6, 7]
+J = [1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4]
 V = Int.(ones(length(I)))
 
-node_weights = [1,2,3,4,5,6,7]
-edge_weights = [1,2,2,1]
+node_weights = [1, 2, 3, 4, 5, 6, 7]
+edge_weights = [1, 2, 2, 1]
 
-A = sparse(I,J,V)
+A = sparse(I, J, V)
 
-h = KaHyPar.HyperGraph(A,node_weights,edge_weights)
+h = KaHyPar.HyperGraph(A, node_weights, edge_weights)
 
-KaHyPar.partition(h,2,configuration = :edge_cut)
+KaHyPar.partition(h, 2; configuration=:edge_cut)
 
-KaHyPar.partition(h,2,configuration = :connectivity)
+KaHyPar.partition(h, 2; configuration=:connectivity)
 
-KaHyPar.partition(h,2,configuration = joinpath(@__DIR__,"../src/config/km1_rKaHyPar_sea20.ini"))
+KaHyPar.partition(
+    h, 2; configuration=joinpath(@__DIR__, "../src/config/km1_rKaHyPar_sea20.ini")
+)
 
 true


### PR DESCRIPTION
This should update the Julia interface to use the v1.3.3 release. It also does some code formatting and adds a quick usage example to the README. All source and test file changes are a result of running Julia formatter with BlueStyle.